### PR TITLE
feat: change `ResponseError` as `class` instead

### DIFF
--- a/.changeset/modern-carpets-whisper.md
+++ b/.changeset/modern-carpets-whisper.md
@@ -1,0 +1,5 @@
+---
+"x-fetch": patch
+---
+
+feat: change `ResponseError` as `class` instead

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "lib/index.js",
-    "limit": "850B"
+    "limit": "860B"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "x-fetch",
   "version": "0.2.5",
   "type": "module",
-  "description": "A simple but elegant `fetch` API wrapper with less than `850B` minified and brotlied, use `fetch` like a charm",
+  "description": "A simple but elegant `fetch` API wrapper with less than `860B` minified and brotlied, use `fetch` like a charm",
   "repository": "git+https://github.com/un-ts/x-fetch.git",
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/x-fetch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   type InterceptorRequest,
   type ApiInterceptor,
   type FetchApiBaseOptions,
+  ResponseError,
 } from './types.js'
 import {
   CONTENT_TYPE,
@@ -101,11 +102,11 @@ export const createFetchApi = (fetch = globalThis.fetch) => {
       if (response.ok) {
         return response
       }
-      throw Object.assign(new Error(response.statusText), {
-        data: await extractDataFromResponse(response, type, true),
+      throw new ResponseError(
         request,
         response,
-      })
+        await extractDataFromResponse(response, type, true),
+      )
     }
 
     const response = await next({

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface FetchApiOptions extends FetchApiBaseOptions {
 }
 
 export interface InterceptorRequest extends FetchApiOptions {
+  headers: Headers
   url: string
 }
 
@@ -61,8 +62,12 @@ export type ApiInterceptor = (
   next: (request: InterceptorRequest) => PromiseLike<Response>,
 ) => PromiseLike<Response> | Response
 
-export interface ResponseError<T = never> extends Error {
-  data?: T | null
-  request: Request
-  response?: Response | null
+export class ResponseError<T = never> extends Error {
+  constructor(
+    public request: InterceptorRequest,
+    public response: Response,
+    public data?: T | null,
+  ) {
+    super(response.statusText)
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,6 @@ export class ResponseError<T = never> extends Error {
     public response: Response,
     public data?: T | null,
   ) {
-    super(response.statusText)
+    super(response.statusText || String(response.status))
   }
 }

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/require-await */
+
+import { createFetchApi, ResponseError } from 'x-fetch'
+
+const assertResponseError = <T>(err: unknown): ResponseError<T> => {
+  if (!(err instanceof ResponseError)) {
+    throw new TypeError('Expected ResponseError')
+  }
+  return err as ResponseError<T>
+}
+
+test('throws ResponseError for 404 response', async () => {
+  // Create a mock fetch function that returns a 404 response
+  const mockFetch = async () =>
+    new Response('Not Found', { status: 404, statusText: 'Not Found' })
+
+  // Create a custom fetchApi using our mock fetch
+  const { fetchApi } = createFetchApi(mockFetch)
+
+  // Test that it throws a ResponseError with the correct message
+  await expect(
+    fetchApi('https://example.com/not-found'),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Not Found]`)
+
+  // Test with try/catch to inspect error properties
+  try {
+    await fetchApi('https://example.com/not-found')
+  } catch (err) {
+    expect(err).toBeInstanceOf(ResponseError)
+    const error = assertResponseError<string>(err)
+    expect(error.response.status).toBe(404)
+    expect(error.message).toBe('Not Found')
+    expect(error.request.url).toBe('https://example.com/not-found')
+    expect(error.data).toBe('Not Found')
+  }
+})
+
+test('throws ResponseError with JSON data for 500 response', async () => {
+  // Create a JSON error body
+  const errorBody = JSON.stringify({ error: 'Server Error', code: 500 })
+
+  // Create a mock fetch function that returns a 500 response
+  const mockFetch = async () =>
+    new Response(errorBody, {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+  // Create a custom fetchApi using our mock fetch
+  const { fetchApi } = createFetchApi(mockFetch)
+
+  // Test that it throws a ResponseError with the correct message
+  await expect(
+    fetchApi('https://example.com/api'),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Internal Server Error]`)
+
+  // Test with try/catch to inspect error properties
+  try {
+    await fetchApi('https://example.com/api')
+  } catch (err) {
+    const error = assertResponseError<{ error: string; code: number }>(err)
+    expect(error).toBeInstanceOf(ResponseError)
+    expect(error.response.status).toBe(500)
+    expect(error.message).toBe('Internal Server Error')
+    expect(error.data).toEqual({ error: 'Server Error', code: 500 })
+  }
+})
+
+test('handles invalid JSON in error response', async () => {
+  // Create an invalid JSON body
+  const invalidJson = '{ "invalid": json }'
+
+  // Create a mock fetch function that returns a 400 response with invalid JSON
+  const mockFetch = async () =>
+    new Response(invalidJson, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+  // Create a custom fetchApi using our mock fetch
+  const { fetchApi } = createFetchApi(mockFetch)
+
+  // Test with try/catch to inspect error properties
+  try {
+    await fetchApi('https://example.com/api')
+  } catch (err) {
+    const error = assertResponseError<string>(err)
+    expect(error).toBeInstanceOf(ResponseError)
+    expect(error.response.status).toBe(400)
+    expect(error.message).toBe('Bad Request')
+    // Should fallback to the raw text when JSON parsing fails
+    expect(typeof error.data).toBe('string')
+    expect(error.data).toBe(invalidJson)
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,9 +3458,9 @@ __metadata:
   linkType: hard
 
 "@pkgr/core@npm:^0.2.0, @pkgr/core@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@pkgr/core@npm:0.2.1"
-  checksum: 10c0/760fcb5999a1794179ad7f498dfc342f9135b846d096bda43f07d4278d5557e87e7c889f5670d1338a802dffcc6a52548cc9be3fbd97d68ce3b3901d5d6160cd
+  version: 0.2.2
+  resolution: "@pkgr/core@npm:0.2.2"
+  checksum: 10c0/86a0507731f2c5172e2225abb42d947b3908d06f0330e7050b5e6ad0c29dab4d586358f2d984aa00fd32bf421ed3405fa97878b352f16c3c23d20398b5fd14e4
   languageName: node
   linkType: hard
 
@@ -5013,14 +5013,14 @@ __metadata:
   linkType: hard
 
 "@yarnpkg/core@npm:^4.0.0-rc.37":
-  version: 4.3.1
-  resolution: "@yarnpkg/core@npm:4.3.1"
+  version: 4.4.0
+  resolution: "@yarnpkg/core@npm:4.4.0"
   dependencies:
     "@arcanis/slice-ansi": "npm:^1.1.1"
     "@types/semver": "npm:^7.1.0"
     "@types/treeify": "npm:^1.0.0"
     "@yarnpkg/fslib": "npm:^3.1.2"
-    "@yarnpkg/libzip": "npm:^3.1.1"
+    "@yarnpkg/libzip": "npm:^3.2.0"
     "@yarnpkg/parsers": "npm:^3.0.3"
     "@yarnpkg/shell": "npm:^4.1.2"
     camelcase: "npm:^5.3.1"
@@ -5042,7 +5042,7 @@ __metadata:
     treeify: "npm:^1.1.0"
     tslib: "npm:^2.4.0"
     tunnel: "npm:^0.0.6"
-  checksum: 10c0/2c926b096e7daa331e1acc92dc3dda11d945e89baebc6cbe2d969289a4b3f0b93d0ef420c5e64908586e8c1174aa2e0f1464ba4f6dccf47ea61169b025722952
+  checksum: 10c0/8d6a7f63ed342fd6aa3808044124228c9bed4e4f94af331e570f0c452da838ebb2be98b5a87d5567f3eb03ef49e26547718fd9740de3c204802b121f3ac69e13
   languageName: node
   linkType: hard
 
@@ -5055,16 +5055,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/libzip@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@yarnpkg/libzip@npm:3.1.1"
+"@yarnpkg/libzip@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@yarnpkg/libzip@npm:3.2.0"
   dependencies:
     "@types/emscripten": "npm:^1.39.6"
     "@yarnpkg/fslib": "npm:^3.1.2"
     tslib: "npm:^2.4.0"
   peerDependencies:
     "@yarnpkg/fslib": ^3.1.2
-  checksum: 10c0/819ad37fbba51f4d7f65fff02b80cd7eb94134d7f7672a8b664a0672f12e710223ff9a8adb4ca565fd6aaa3432e74e964ee71d5ed929e900657c3a9fde9a381d
+  checksum: 10c0/ee9415a436be4d196756a834840c9f068130ba073d7b45bb3cfeed86fa385603f1f36e71fca9c41ae19e0c598d8e3f9bc33eeb391b20504f076e591b9562873c
   languageName: node
   linkType: hard
 
@@ -6784,9 +6784,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.134
-  resolution: "electron-to-chromium@npm:1.5.134"
-  checksum: 10c0/ba0c8b3a86e139b142ce797e807f3a7b4b5708d8a550d820cc5467bf22fc62517fa9c2a38c4fec975c96f321f18918be1bcae41687f1715889a0ac6122fbfa6d
+  version: 1.5.135
+  resolution: "electron-to-chromium@npm:1.5.135"
+  checksum: 10c0/d431751080e659dd089423cbf7e5efcd1c6672a06b9552b2ebfb80caf0e2c442a2ee883f445f70ffb53c4f740b3fe8f6607760d9a15d6db2d3ba44dff39fc901
   languageName: node
   linkType: hard
 
@@ -10226,8 +10226,8 @@ __metadata:
   linkType: hard
 
 "listr2@npm:^8.2.5":
-  version: 8.2.5
-  resolution: "listr2@npm:8.2.5"
+  version: 8.3.1
+  resolution: "listr2@npm:8.3.1"
   dependencies:
     cli-truncate: "npm:^4.0.0"
     colorette: "npm:^2.0.20"
@@ -10235,7 +10235,7 @@ __metadata:
     log-update: "npm:^6.1.0"
     rfdc: "npm:^1.4.1"
     wrap-ansi: "npm:^9.0.0"
-  checksum: 10c0/f5a9599514b00c27d7eb32d1117c83c61394b2a985ec20e542c798bf91cf42b19340215701522736f5b7b42f557e544afeadec47866e35e5d4f268f552729671
+  checksum: 10c0/09c99c7e2ce52b7fc9cde9897907501380083e2058c9d8402c000366e4ec89b1b32ffb3e5aff6f12a9fd4d70091af6110c796bf6e53bf9655e2acb360ad0d123
   languageName: node
   linkType: hard
 
@@ -13185,8 +13185,8 @@ __metadata:
   linkType: hard
 
 "remark-lint-fenced-code-flag@npm:^4.0.0":
-  version: 4.1.1
-  resolution: "remark-lint-fenced-code-flag@npm:4.1.1"
+  version: 4.2.0
+  resolution: "remark-lint-fenced-code-flag@npm:4.2.0"
   dependencies:
     "@types/mdast": "npm:^4.0.0"
     mdast-util-phrasing: "npm:^4.0.0"
@@ -13194,7 +13194,7 @@ __metadata:
     unified-lint-rule: "npm:^3.0.0"
     unist-util-position: "npm:^5.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
-  checksum: 10c0/f24f34d7734b8bb1320bd7503c1ebe85bbe24d5a3f7b9df4b1ff0a53243f649930d48ef6705d9b6ba4935859e46a5d2629cdac972dfd3fa0c89cf18c6f056d76
+  checksum: 10c0/bed2d84be56f61958f6257340b151b3579a2daa13c7bd8fb59f60555c647554dc43780f9bda09d37f6dbe6b7227b004398f57f51d43928641b8702615369dc3d
   languageName: node
   linkType: hard
 
@@ -13635,8 +13635,8 @@ __metadata:
   linkType: hard
 
 "remark-lint-no-undefined-references@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "remark-lint-no-undefined-references@npm:5.0.1"
+  version: 5.0.2
+  resolution: "remark-lint-no-undefined-references@npm:5.0.2"
   dependencies:
     "@types/mdast": "npm:^4.0.0"
     collapse-white-space: "npm:^2.0.0"
@@ -13646,7 +13646,7 @@ __metadata:
     unist-util-position: "npm:^5.0.0"
     unist-util-visit-parents: "npm:^6.0.0"
     vfile-location: "npm:^5.0.0"
-  checksum: 10c0/62e083a0c492f4dad5725fa9929986f25ece50f3fbf5d81edf99ebe202c4dde0f40ed37083c83b14cdc24ac64cbab5abfcb1d6801839b89107f6d6ec5efe1055
+  checksum: 10c0/49139a9fd77ecff020669518e9f7b3da65b189a4229d63d6eb492095290d489cfe0ab7e4fa51f19007383bd5d1e7c3a84a8a4bf962fda912222af510146e5657
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5839,9 +5839,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001669, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001712
-  resolution: "caniuse-lite@npm:1.0.30001712"
-  checksum: 10c0/b3df8bdcc3335969380c2e47acb36c89bfc7f8fb4ef7ee2a5380e30ba46aa69e9d411654bc29894a06c201a1d60d490ab9b92787f3b66d7a7a38d71360e68215
+  version: 1.0.30001713
+  resolution: "caniuse-lite@npm:1.0.30001713"
+  checksum: 10c0/f5468abfe73ce30e29cc8bde2ea67df2aab69032bdd93345e0640efefb76b7901c84fe1d28d591a797e65fe52fc24cae97060bb5552f9f9740322aff95ce2f9d
   languageName: node
   linkType: hard
 
@@ -7220,13 +7220,13 @@ __metadata:
   linkType: hard
 
 "eslint-config-prettier@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "eslint-config-prettier@npm:10.1.1"
+  version: 10.1.2
+  resolution: "eslint-config-prettier@npm:10.1.2"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: 10c0/3dbfdf6495dd62e2e1644ea9e8e978100dabcd8740fd264df1222d130001a1e8de05d6ed6c67d3a60727386a07507f067d1ca79af6d546910414beab19e7966e
+  checksum: 10c0/c22c8e29193cc8fd70becf1c2dd072513f2b3004a175c2a49404c79d1745ba4dc0edc2afd00d16b0e26d24f95813a0469e7445a25104aec218f6d84cdb1697e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `ResponseError` class for improved error handling in the fetch API.
  - Added a new property for HTTP headers in the request interface.
- **Bug Fixes**
  - Enhanced error handling for various HTTP responses, ensuring accurate error messaging and data retrieval.
- **Chores**
  - Updated the size limit for the minified output in the configuration.
  - Modified the package description to reflect the new size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->