### PR TITLE
feat: rename `fetchApi` to `xfetch`

### DIFF
--- a/.changeset/fuzzy-bobcats-flow.md
+++ b/.changeset/fuzzy-bobcats-flow.md
@@ -1,0 +1,5 @@
+---
+"x-fetch": patch
+---
+
+feat: rename `fetchApi` to `xfetch`

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "lib/index.js",
-    "limit": "860B"
+    "limit": "880B"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -30,26 +30,29 @@ A simple but elegant `fetch` API wrapper with less than `850B` minified and brot
 ### Install
 
 ```sh
-# pnpm
-pnpm add x-fetch
+# npm
+npm i x-fetch
 
 # yarn
 yarn add x-fetch
 
-# npm
-npm i x-fetch
+# pnpm
+pnpm add x-fetch
+
+# bun
+bun add x-fetch
 ```
 
 ### API
 
 ```ts
-import { ApiMethod, createFetchApi, fetchApi, interceptors } from 'x-fetch'
+import { ApiMethod, createXFetch, interceptors, xfetch } from 'x-fetch'
 
 // plain url, GET method
-await fetchApi('url')
+await xfetch('url')
 
 // with options, `method`, `body`, `query`, etc.
-await fetchApi('url', {
+await xfetch('url', {
   method: ApiMethod.POST, // or 'POST'
   // plain object or array, or BodyInit
   body: {},
@@ -74,8 +77,8 @@ interceptors.use(interceptor)
 // remove interceptor
 interceptors.eject(interceptor)
 
-// create a new isolated `fetchApi` with its own `interceptors`
-const { fetchApi, interceptors } = createFetchApi()
+// create a new isolated `xfetch` with its own `interceptors`
+const { xfetch, interceptors } = createXFetch()
 ```
 
 [![Sponsors](https://raw.githubusercontent.com/1stG/static/master/sponsors.svg)](https://github.com/sponsors/JounQin)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "x-fetch",
   "version": "0.2.5",
   "type": "module",
-  "description": "A simple but elegant `fetch` API wrapper with less than `860B` minified and brotlied, use `fetch` like a charm",
+  "description": "A simple but elegant `fetch` API wrapper with less than `880B` minified and brotlied, use `fetch` like a charm",
   "repository": "git+https://github.com/un-ts/x-fetch.git",
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/x-fetch",
@@ -42,7 +42,7 @@
   "scripts": {
     "build": "concurrently -r 'yarn:build:*'",
     "build:r": "r -f cjs",
-    "build:tsc": "tsc -p src",
+    "build:tsc": "tsc -p src --declaration false && tsc -p src --emitDeclarationOnly true --removeComments false",
     "clean": "rimraf -g .type-coverage coverage dist lib '.*cache'",
     "dev": "vitest",
     "docs": "vite",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,31 +47,31 @@ export class ApiInterceptors {
   }
 }
 
-export const createFetchApi = (fetch = globalThis.fetch) => {
+export const createXFetch = (fetch = globalThis.fetch) => {
   const interceptors = new ApiInterceptors()
 
-  function fetchApi(
+  function xfetch(
     url: string,
     options: FetchApiBaseOptions & { type: null },
   ): Promise<Response>
   // @ts-expect-error -- no idea, it sucks
-  function fetchApi(
+  function xfetch(
     url: string,
     options: FetchApiBaseOptions & { type: 'arraybuffer' },
   ): Promise<ArrayBuffer>
-  function fetchApi(
+  function xfetch(
     url: string,
     options: FetchApiBaseOptions & { type: 'blob' },
   ): Promise<Blob>
-  function fetchApi(
+  function xfetch(
     url: string,
     options: FetchApiBaseOptions & { type: 'text' },
   ): Promise<string>
-  function fetchApi<T>(
+  function xfetch<T>(
     url: string,
     options?: FetchApiBaseOptions & { type?: 'json' },
   ): Promise<T>
-  async function fetchApi(
+  async function xfetch(
     url: string,
     {
       method = ApiMethod.GET,
@@ -120,7 +120,20 @@ export const createFetchApi = (fetch = globalThis.fetch) => {
     return type == null ? response : extractDataFromResponse(response, type)
   }
 
-  return { interceptors, fetchApi }
+  return {
+    interceptors,
+    xfetch,
+    /**
+     * @deprecated Use {@link xfetch} instead.
+     */
+    fetchApi: xfetch,
+  }
 }
 
-export const { interceptors, fetchApi } = createFetchApi()
+/**
+ * @deprecated Use {@link createXFetch} instead.
+ */
+export const createFetchApi = createXFetch
+
+// eslint-disable-next-line sonarjs/deprecation
+export const { interceptors, xfetch, fetchApi } = createXFetch()

--- a/test/basic.spec.ts
+++ b/test/basic.spec.ts
@@ -1,8 +1,8 @@
-import { type ApiInterceptor, fetchApi, interceptors } from 'x-fetch'
+import { type ApiInterceptor, xfetch, interceptors } from 'x-fetch'
 
 test('it should just work', async () => {
   expect(
-    await fetchApi<{
+    await xfetch<{
       id: number
       userId: number
     }>('https://jsonplaceholder.typicode.com/todos/1'),
@@ -27,14 +27,14 @@ test('interceptors should just work', async () => {
     return next(req)
   }
 
-  await expect(fetchApi('/todos/1')).rejects.toThrowErrorMatchingInlineSnapshot(
+  await expect(xfetch('/todos/1')).rejects.toThrowErrorMatchingInlineSnapshot(
     '[TypeError: Failed to parse URL from /todos/1]',
   )
 
   interceptors.use(interceptor)
 
   expect(
-    await fetchApi<{
+    await xfetch<{
       id: number
       userId: number
     }>('todos/1'),
@@ -50,7 +50,7 @@ test('interceptors should just work', async () => {
   expect(interceptors.eject(interceptor)).toBe(true)
   expect(interceptors.eject(interceptor)).toBe(false)
 
-  await expect(fetchApi('/todos/1')).rejects.toThrowErrorMatchingInlineSnapshot(
+  await expect(xfetch('/todos/1')).rejects.toThrowErrorMatchingInlineSnapshot(
     '[TypeError: Failed to parse URL from /todos/1]',
   )
 })

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers, @typescript-eslint/require-await */
 
-import { createFetchApi, ResponseError } from 'x-fetch'
+import { createXFetch, ResponseError } from 'x-fetch'
 
 const assertResponseError = <T>(err: unknown): ResponseError<T> => {
   if (!(err instanceof ResponseError)) {
@@ -14,17 +14,17 @@ test('throws ResponseError for 404 response', async () => {
   const mockFetch = async () =>
     new Response('Not Found', { status: 404, statusText: 'Not Found' })
 
-  // Create a custom fetchApi using our mock fetch
-  const { fetchApi } = createFetchApi(mockFetch)
+  // Create a custom xfetch using our mock fetch
+  const { xfetch } = createXFetch(mockFetch)
 
   // Test that it throws a ResponseError with the correct message
   await expect(
-    fetchApi('https://example.com/not-found'),
+    xfetch('https://example.com/not-found'),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Not Found]`)
 
   // Test with try/catch to inspect error properties
   try {
-    await fetchApi('https://example.com/not-found')
+    await xfetch('https://example.com/not-found')
   } catch (err) {
     expect(err).toBeInstanceOf(ResponseError)
     const error = assertResponseError<string>(err)
@@ -47,17 +47,17 @@ test('throws ResponseError with JSON data for 500 response', async () => {
       headers: { 'Content-Type': 'application/json' },
     })
 
-  // Create a custom fetchApi using our mock fetch
-  const { fetchApi } = createFetchApi(mockFetch)
+  // Create a custom xfetch using our mock fetch
+  const { xfetch } = createXFetch(mockFetch)
 
   // Test that it throws a ResponseError with the correct message
   await expect(
-    fetchApi('https://example.com/api'),
+    xfetch('https://example.com/api'),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Internal Server Error]`)
 
   // Test with try/catch to inspect error properties
   try {
-    await fetchApi('https://example.com/api')
+    await xfetch('https://example.com/api')
   } catch (err) {
     const error = assertResponseError<{ error: string; code: number }>(err)
     expect(error).toBeInstanceOf(ResponseError)
@@ -79,12 +79,12 @@ test('handles invalid JSON in error response', async () => {
       headers: { 'Content-Type': 'application/json' },
     })
 
-  // Create a custom fetchApi using our mock fetch
-  const { fetchApi } = createFetchApi(mockFetch)
+  // Create a custom xfetch using our mock fetch
+  const { xfetch } = createXFetch(mockFetch)
 
   // Test with try/catch to inspect error properties
   try {
-    await fetchApi('https://example.com/api')
+    await xfetch('https://example.com/api')
   } catch (err) {
     const error = assertResponseError<string>(err)
     expect(error).toBeInstanceOf(ResponseError)

--- a/test/error.spec.ts
+++ b/test/error.spec.ts
@@ -2,11 +2,10 @@
 
 import { createXFetch, ResponseError } from 'x-fetch'
 
-const assertResponseError = <T>(err: unknown): ResponseError<T> => {
+function assertResponseError<T>(err: unknown): asserts err is ResponseError<T> {
   if (!(err instanceof ResponseError)) {
     throw new TypeError('Expected ResponseError')
   }
-  return err as ResponseError<T>
 }
 
 test('throws ResponseError for 404 response', async () => {
@@ -25,9 +24,9 @@ test('throws ResponseError for 404 response', async () => {
   // Test with try/catch to inspect error properties
   try {
     await xfetch('https://example.com/not-found')
-  } catch (err) {
-    expect(err).toBeInstanceOf(ResponseError)
-    const error = assertResponseError<string>(err)
+  } catch (error) {
+    expect(error).toBeInstanceOf(ResponseError)
+    assertResponseError<string>(error)
     expect(error.response.status).toBe(404)
     expect(error.message).toBe('Not Found')
     expect(error.request.url).toBe('https://example.com/not-found')
@@ -58,8 +57,8 @@ test('throws ResponseError with JSON data for 500 response', async () => {
   // Test with try/catch to inspect error properties
   try {
     await xfetch('https://example.com/api')
-  } catch (err) {
-    const error = assertResponseError<{ error: string; code: number }>(err)
+  } catch (error) {
+    assertResponseError<{ error: string; code: number }>(error)
     expect(error).toBeInstanceOf(ResponseError)
     expect(error.response.status).toBe(500)
     expect(error.message).toBe('Internal Server Error')
@@ -85,8 +84,8 @@ test('handles invalid JSON in error response', async () => {
   // Test with try/catch to inspect error properties
   try {
     await xfetch('https://example.com/api')
-  } catch (err) {
-    const error = assertResponseError<string>(err)
+  } catch (error) {
+    assertResponseError<string>(error)
     expect(error).toBeInstanceOf(ResponseError)
     expect(error.response.status).toBe(400)
     expect(error.message).toBe('Bad Request')


### PR DESCRIPTION
close #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed primary API methods for improved consistency; legacy naming remains supported but is now deprecated.
- **Documentation**
	- Updated installation instructions and API usage examples with revised package manager ordering and clear guidance reflecting the naming changes.
- **Chores**
	- Adjusted configuration thresholds and refined build scripts to align with updated size limits.
- **Tests**
	- Modified test cases to match the updated API naming and enhanced type safety in error validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->