### PR TITLE
feat: make `next()` request optional, default to previous request

### DIFF
--- a/.changeset/optional-next-request.md
+++ b/.changeset/optional-next-request.md
@@ -1,0 +1,5 @@
+---
+"x-fetch": patch
+---
+
+Make `next()`'s `request` optional, defaults to the previous request when omitted.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
     "path": "lib/index.js",
-    "limit": "881B"
+    "limit": "885B"
   }
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export const createXFetch = (fetch = globalThis.fetch) => {
       request: InterceptorRequest,
     ): Promise<Response> => {
       if (i < interceptors.length) {
-        return interceptors.at(i)!(request, r => dispatch(i + 1, r))
+        return interceptors.at(i)!(request, r => dispatch(i + 1, r ?? request))
       }
 
       const { body, url, query, ...rest } = request

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface InterceptorRequest extends FetchApiOptions {
 
 export type ApiInterceptor = (
   request: InterceptorRequest,
-  next: (request: InterceptorRequest) => PromiseLike<Response>,
+  next: (request?: InterceptorRequest) => PromiseLike<Response>,
 ) => PromiseLike<Response> | Response
 
 export class ResponseError<T = never> extends Error {

--- a/test/interceptor.spec.ts
+++ b/test/interceptor.spec.ts
@@ -15,11 +15,11 @@ test('next() can be called multiple times for retry', async () => {
 
   const { interceptors, xfetch } = createXFetch(mockFetch)
 
-  const retryInterceptor: ApiInterceptor = async (req, next) => {
+  const retryInterceptor: ApiInterceptor = async (_req, next) => {
     try {
-      return await next(req)
+      return await next()
     } catch {
-      return next(req)
+      return next()
     }
   }
 
@@ -48,10 +48,10 @@ test('interceptor can modify request between retries', async () => {
 
   const authRetryInterceptor: ApiInterceptor = async (req, next) => {
     try {
-      return await next(req)
+      return await next()
     } catch {
       req.headers.set('Authorization', 'Bearer token')
-      return next(req)
+      return next()
     }
   }
 
@@ -74,16 +74,16 @@ test('multiple interceptors work correctly', async () => {
 
   const { interceptors, xfetch } = createXFetch(mockFetch)
 
-  const a: ApiInterceptor = async (req, next) => {
+  const a: ApiInterceptor = async (_req, next) => {
     callOrder.push('a-in')
-    const res = await next(req)
+    const res = await next()
     callOrder.push('a-out')
     return res
   }
 
-  const b: ApiInterceptor = async (req, next) => {
+  const b: ApiInterceptor = async (_req, next) => {
     callOrder.push('b-in')
-    const res = await next(req)
+    const res = await next()
     callOrder.push('b-out')
     return res
   }


### PR DESCRIPTION
## Summary

- `ApiInterceptor.next` now accepts an optional request parameter: `(request?: InterceptorRequest) => ...`
- When omitted or `null`, defaults to the previous request — so `next()` reuses the same request without needing to pass it explicitly
- Updated tests to use the simpler `next()` form where appropriate

## Test plan

- All 12 tests pass